### PR TITLE
Rinomina `openFavorites` in `openGallery` in `ImagePredictionActivity`

### DIFF
--- a/app/src/main/java/com/myapp/chefgpt/ImagePredictionActivity.kt
+++ b/app/src/main/java/com/myapp/chefgpt/ImagePredictionActivity.kt
@@ -76,7 +76,7 @@ class ImagePredictionActivity : AppCompatActivity() {
 
         //Settaggio dei bottoni, textview, imageview e toolbar
         val takePictureButton = findViewById<Button>(R.id.openCamera)
-        val pickImageButton = findViewById<Button>(R.id.openFavorites)
+        val pickImageButton = findViewById<Button>(R.id.openGallery)
         val predictButton = findViewById<Button>(R.id.predictButton)
         val buttonToRecipeResult = findViewById<Button>(R.id.toRecipeResult)
         val foodName= findViewById<TextView>(R.id.foodName)

--- a/app/src/main/res/layout-land/activity_imageprediction.xml
+++ b/app/src/main/res/layout-land/activity_imageprediction.xml
@@ -34,7 +34,7 @@
         app:layout_constraintVertical_bias="0.26">
 
         <Button
-            android:id="@+id/openFavorites"
+            android:id="@+id/openGallery"
             android:layout_width="174dp"
             android:layout_height="56dp"
             android:layout_marginStart="15dp"
@@ -66,7 +66,7 @@
     <Button
         android:id="@+id/predictButton"
         android:layout_width="171dp"
-        android:layout_height="74dp"
+        android:layout_height="64dp"
         android:layout_marginTop="20dp"
         android:layout_weight="1"
         android:text="@string/Predict"

--- a/app/src/main/res/layout-land/activity_reciperesult.xml
+++ b/app/src/main/res/layout-land/activity_reciperesult.xml
@@ -32,8 +32,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.872"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.587">
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/textRecipe"
@@ -58,6 +57,6 @@
         app:layout_constraintHorizontal_bias="0.827"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/scrollView"
-        app:layout_constraintVertical_bias="0.157" />
+        app:layout_constraintVertical_bias="0.2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_imageprediction.xml
+++ b/app/src/main/res/layout/activity_imageprediction.xml
@@ -25,8 +25,9 @@
       android:layout_weight="3">
 
     <Button
-        android:id="@+id/openFavorites"
-        android:layout_width="174dp"
+        android:id="@+id/openGallery"
+        android:layout_width="0dp"
+        android:layout_weight="1"
         android:layout_height="56dp"
         android:layout_marginStart="15dp"
         android:text="@string/Gallery"
@@ -40,7 +41,8 @@
 
     <Button
         android:id="@+id/openCamera"
-        android:layout_width="174dp"
+        android:layout_width="0dp"
+        android:layout_weight="1"
         android:layout_height="56dp"
         android:layout_marginEnd="15dp"
         android:text="@string/Camera"
@@ -57,7 +59,7 @@
   <Button
       android:id="@+id/predictButton"
       android:layout_width="wrap_content"
-      android:layout_height="0dp"
+      android:layout_height="22dp"
       android:layout_weight="1"
       android:text="@string/Predict"
       android:textSize="20sp"
@@ -77,7 +79,7 @@
   <Button
       android:id="@+id/toRecipeResult"
       android:layout_width="wrap_content"
-      android:layout_height="0dp"
+      android:layout_height="22dp"
       android:layout_weight="1"
       android:layout_marginBottom="25dp"
       android:text="@string/Recipe"


### PR DESCRIPTION
Questa commit aggiorna l'ID del pulsante `openFavorites` in `openGallery` nel file `ImagePredictionActivity.kt` e nei relativi file di layout (`activity_imageprediction.xml` e `activity_imageprediction.xml` per la modalità landscape).

Sono state apportate anche le seguenti modifiche di layout:
- `activity_reciperesult.xml` (landscape): aggiustamenti minori ai vincoli della `ScrollView` e del pulsante `toFavorites`.
- `activity_imageprediction.xml`:
    - I pulsanti `openGallery` e `openCamera` ora usano `layout_weight="1"` e `layout_width="0dp"` per una distribuzione uniforme dello spazio.
    - L'altezza dei pulsanti `predictButton` e `toRecipeResult` è stata modificata da `0dp` a `22dp`.
- `activity_imageprediction.xml` (landscape): l'altezza del `predictButton` è stata modificata da `74dp` a `64dp`.